### PR TITLE
Update assets-client.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ dkg.nodeInfo().then(result => console.log(result));
 let ual = "";
 // provisioning an asset
 options = { filepath: './kg-example.json', keywords: ["Product", "Executive Objects", "ACME"], visibility: "public" };
-dkg.assets.provision(options).then((result) => {
+dkg.assets.create(options).then((result) => {
     ual = result[0].data.metadata.UALs[0]
     console.log(JSON.stringify(result, null, 2))
 });

--- a/client/assets-client.js
+++ b/client/assets-client.js
@@ -13,7 +13,7 @@ class AssetsClient extends AbstractClient {
      * @param {string} options.data - stringified dataset (optional)
      * @param {string[]} options.keywords (optional)
      */
-    create(options) {
+    provision(options) {
         if (!options || (!options.filepath && !options.data)) {
             throw Error("Please provide publish options in order to publish.");
         }

--- a/client/assets-client.js
+++ b/client/assets-client.js
@@ -13,7 +13,7 @@ class AssetsClient extends AbstractClient {
      * @param {string} options.data - stringified dataset (optional)
      * @param {string[]} options.keywords (optional)
      */
-    provision(options) {
+    create(options) {
         if (!options || (!options.filepath && !options.data)) {
             throw Error("Please provide publish options in order to publish.");
         }


### PR DESCRIPTION
We need to rename it to provision because docs in READMEN.MD uses "provision" method and not "create" method and will throw errors if someone use these examples